### PR TITLE
Set max-parallel to 5 to avoid abuse detection

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -112,6 +112,7 @@ jobs:
     # particular tracks.
     strategy:
       fail-fast: false
+      max-parallel: 5
       matrix:
         track: ${{ fromJson(needs.fetch-tracks.outputs.tracks) }}
 


### PR DESCRIPTION
[skip ci]