### PR TITLE
Fix description of `x:type` labels

### DIFF
--- a/global-files/.github/labels.yml
+++ b/global-files/.github/labels.yml
@@ -116,8 +116,8 @@
   description: "Someone is working on this issue"
   color: "4231af"
 
-# The x:type labels describe how much Exercism knowledge
-# is required by the contributor
+# The x:type labels describe the type of work the contributor
+# will be engaged in
 - name: "x:type/ci"
   description: "Work on Continuous Integration (e.g. GitHub Actions workflows)"
   color: "3c2d9f"


### PR DESCRIPTION
Previously, the description of the `x:type` labels was the same as that
for the `x:knowledge` labels.

This commit reflects the change in `exercism/docs`:
https://github.com/exercism/docs/commit/72bee20ad804

---

Do we want to do this? Does merging a PR in this repo open a PR in every downstream repo?