### PR TITLE
Reduce number of parallel jobs to 1

### DIFF
--- a/.github/workflows/sync-rest.yml
+++ b/.github/workflows/sync-rest.yml
@@ -120,7 +120,7 @@ jobs:
     # particular tracks.
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 1
       matrix:
         track: ${{ fromJson(needs.fetch-tracks.outputs.tracks) }}
 

--- a/.github/workflows/sync-tooling.yml
+++ b/.github/workflows/sync-tooling.yml
@@ -110,7 +110,7 @@ jobs:
     # particular tracks.
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 1
       matrix:
         track: ${{ fromJson(needs.fetch-tracks.outputs.tracks) }}
 

--- a/.github/workflows/sync-tracks.yml
+++ b/.github/workflows/sync-tracks.yml
@@ -110,7 +110,7 @@ jobs:
     # particular tracks.
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 1
       matrix:
         track: ${{ fromJson(needs.fetch-tracks.outputs.tracks) }}
 


### PR DESCRIPTION
We still hit throttling issues with max-parallel: 5, let's just go to the slowest possible value.

[ci skip]