### PR TITLE
Add labels to sync-ignore

### DIFF
--- a/.github/workflows/sync-rest.yml
+++ b/.github/workflows/sync-rest.yml
@@ -15,6 +15,8 @@ on:
     paths-ignore:
       - README.md
       - LICENSE
+      - .github/labels.yml
+      - .github/workflows/sync-labels.yml
 
 env:
   BOT_USERNAME: "exercism-bot"

--- a/.github/workflows/sync-tooling.yml
+++ b/.github/workflows/sync-tooling.yml
@@ -13,6 +13,8 @@ on:
     paths-ignore:
       - README.md
       - LICENSE
+      - .github/labels.yml
+      - .github/workflows/sync-labels.yml
 
 env:
   BOT_USERNAME: "exercism-bot"

--- a/.github/workflows/sync-tracks.yml
+++ b/.github/workflows/sync-tracks.yml
@@ -13,6 +13,8 @@ on:
     paths-ignore:
       - README.md
       - LICENSE
+      - .github/labels.yml
+      - .github/workflows/sync-labels.yml
 
 env:
   BOT_USERNAME: "exercism-bot"


### PR DESCRIPTION
This allows us to safely merge updates to the labels without skipping and manually running the label sync

(I hope)