### PR TITLE
Change label colours to light grays

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -22,40 +22,40 @@
 # The `x:action/<value>` labels describe what sort of work the contributor will be engaged in when working on the issue
 - name: "x:action/create"
   description: "Work on something from scratch"
-  color: "d3d3d3"
+  color: "ffffff"
 
 - name: "x:action/fix"
   description: "Fix an issue"
-  color: "d3d3d3"
+  color: "ffffff"
 
 - name: "x:action/improve"
   description: "Improve existing functionality/content"
-  color: "d3d3d3"
+  color: "ffffff"
 
 - name: "x:action/proofread"
   description: "Proofread text"
-  color: "d3d3d3"
+  color: "ffffff"
 
 - name: "x:action/sync"
   description: "Sync content with its latest version"
-  color: "d3d3d3"
+  color: "ffffff"
 
 # The `x:knowledge/<value>` labels describe how much Exercism knowledge is required by the contributor
 - name: "x:knowledge/none"
   description: "No existing Exercism knowledge required"
-  color: "c0c0c0"
+  color: "ffffff"
 
 - name: "x:knowledge/elementary"
   description: "Little Exercism knowledge required"
-  color: "c0c0c0"
+  color: "ffffff"
 
 - name: "x:knowledge/intermediate"
   description: "Quite a bit of Exercism knowledge required"
-  color: "c0c0c0"
+  color: "ffffff"
 
 - name: "x:knowledge/advanced"
   description: "Comprehensive Exercism knowledge required"
-  color: "c0c0c0"
+  color: "ffffff"
 
 # The `x:module/<value>` labels indicate what part of Exercism the contributor will be working on
 - name: "x:module/analyzer"
@@ -89,49 +89,49 @@
 # The `x:size/<value>` labels describe the expected amount of work for a contributor
 - name: "x:size/tiny"
   description: "Tiny amount of work"
-  color: "e0e0e0"
+  color: "ffffff"
 
 - name: "x:size/small"
   description: "Small amount of work"
-  color: "e0e0e0"
+  color: "ffffff"
 
 - name: "x:size/medium"
   description: "Medium amount of work"
-  color: "e0e0e0"
+  color: "ffffff"
 
 - name: "x:size/large"
   description: "Large amount of work"
-  color: "e0e0e0"
+  color: "ffffff"
 
 - name: "x:size/massive"
   description: "Massive amount of work"
-  color: "e0e0e0"
+  color: "ffffff"
 
 # The `x:status/<value>` label indicates if there is already someone working on the issue
 - name: "x:status/claimed"
   description: "Someone is working on this issue"
-  color: "e8e8e8"
+  color: "ffffff"
 
 # The `x:type/<value>` labels describe what type of work the contributor will be engaged in
 - name: "x:type/ci"
   description: "Work on Continuous Integration (e.g. GitHub Actions workflows)"
-  color: "e8e8e8"
+  color: "ffffff"
 
 - name: "x:type/coding"
   description: "Write code that is not student-facing content (e.g. test-runners, generators, but not exercises)"
-  color: "e8e8e8"
+  color: "ffffff"
 
 - name: "x:type/content"
   description: "Work on content (e.g. exercises, concepts)"
-  color: "e8e8e8"
+  color: "ffffff"
 
 - name: "x:type/docker"
   description: "Work on Dockerfiles"
-  color: "e8e8e8"
+  color: "ffffff"
 
 - name: "x:type/docs"
   description: "Work on Documentation"
-  color: "e8e8e8"
+  color: "ffffff"
 
 # This label can be added to accept PRs as part of Hacktoberfest
 - name: "hacktoberfest-accepted"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -22,116 +22,116 @@
 # The `x:action/<value>` labels describe what sort of work the contributor will be engaged in when working on the issue
 - name: "x:action/create"
   description: "Work on something from scratch"
-  color: "6f60d2"
+  color: "d3d3d3"
 
 - name: "x:action/fix"
   description: "Fix an issue"
-  color: "6f60d2"
+  color: "d3d3d3"
 
 - name: "x:action/improve"
   description: "Improve existing functionality/content"
-  color: "6f60d2"
+  color: "d3d3d3"
 
 - name: "x:action/proofread"
   description: "Proofread text"
-  color: "6f60d2"
+  color: "d3d3d3"
 
 - name: "x:action/sync"
   description: "Sync content with its latest version"
-  color: "6f60d2"
+  color: "d3d3d3"
 
 # The `x:knowledge/<value>` labels describe how much Exercism knowledge is required by the contributor
 - name: "x:knowledge/none"
   description: "No existing Exercism knowledge required"
-  color: "604fcd"
+  color: "c0c0c0"
 
 - name: "x:knowledge/elementary"
   description: "Little Exercism knowledge required"
-  color: "604fcd"
+  color: "c0c0c0"
 
 - name: "x:knowledge/intermediate"
   description: "Quite a bit of Exercism knowledge required"
-  color: "604fcd"
+  color: "c0c0c0"
 
 - name: "x:knowledge/advanced"
   description: "Comprehensive Exercism knowledge required"
-  color: "604fcd"
+  color: "c0c0c0"
 
 # The `x:module/<value>` labels indicate what part of Exercism the contributor will be working on
 - name: "x:module/analyzer"
   description: "Work on Analyzers"
-  color: "5240c9"
+  color: "ffffff"
 
 - name: "x:module/concept"
   description: "Work on Concepts"
-  color: "5240c9"
+  color: "ffffff"
 
 - name: "x:module/concept-exercise"
   description: "Work on Concept Exercises"
-  color: "5240c9"
+  color: "ffffff"
 
 - name: "x:module/generator"
   description: "Work on Exercise generators"
-  color: "5240c9"
+  color: "ffffff"
 
 - name: "x:module/practice-exercise"
   description: "Work on Practice Exercises"
-  color: "5240c9"
+  color: "ffffff"
 
 - name: "x:module/representer"
   description: "Work on Representers"
-  color: "5240c9"
+  color: "ffffff"
 
 - name: "x:module/test-runner"
   description: "Work on Test Runners"
-  color: "5240c9"
+  color: "ffffff"
 
 # The `x:size/<value>` labels describe the expected amount of work for a contributor
 - name: "x:size/tiny"
   description: "Tiny amount of work"
-  color: "4836bf"
+  color: "e0e0e0"
 
 - name: "x:size/small"
   description: "Small amount of work"
-  color: "4836bf"
+  color: "e0e0e0"
 
 - name: "x:size/medium"
   description: "Medium amount of work"
-  color: "4836bf"
+  color: "e0e0e0"
 
 - name: "x:size/large"
   description: "Large amount of work"
-  color: "4836bf"
+  color: "e0e0e0"
 
 - name: "x:size/massive"
   description: "Massive amount of work"
-  color: "4836bf"
+  color: "e0e0e0"
 
 # The `x:status/<value>` label indicates if there is already someone working on the issue
 - name: "x:status/claimed"
   description: "Someone is working on this issue"
-  color: "4231af"
+  color: "e8e8e8"
 
 # The `x:type/<value>` labels describe what type of work the contributor will be engaged in
 - name: "x:type/ci"
   description: "Work on Continuous Integration (e.g. GitHub Actions workflows)"
-  color: "3c2d9f"
+  color: "e8e8e8"
 
 - name: "x:type/coding"
   description: "Write code that is not student-facing content (e.g. test-runners, generators, but not exercises)"
-  color: "3c2d9f"
+  color: "e8e8e8"
 
 - name: "x:type/content"
   description: "Work on content (e.g. exercises, concepts)"
-  color: "3c2d9f"
+  color: "e8e8e8"
 
 - name: "x:type/docker"
   description: "Work on Dockerfiles"
-  color: "3c2d9f"
+  color: "e8e8e8"
 
 - name: "x:type/docs"
   description: "Work on Documentation"
-  color: "3c2d9f"
+  color: "e8e8e8"
 
 # This label can be added to accept PRs as part of Hacktoberfest
 - name: "hacktoberfest-accepted"


### PR DESCRIPTION
The current colours draw a lot of attention and make it hard to find issues on GitHub for maintainers.

## Examples

Some (incomplete) examples in Default Light and Colourblind Dark:

### Current state

![grafik](https://user-images.githubusercontent.com/20866761/135725015-b1468fbd-4595-411a-84c3-f4371a47c7a3.png)
![grafik](https://user-images.githubusercontent.com/20866761/135725020-b8fc6bcc-3ac1-471f-b9f9-1a5627f412cc.png)

### All `ffffff`

![grafik](https://user-images.githubusercontent.com/20866761/135724890-c53f394a-786d-4fa4-861a-884283b39d01.png)
![grafik](https://user-images.githubusercontent.com/20866761/135724891-964a05f3-3214-4d00-9d3a-69fb74d98c68.png)

### Random greys

![grafik](https://user-images.githubusercontent.com/20866761/135725121-ef5e614e-d021-40ef-9bc9-eef6983ceb8e.png)
![grafik](https://user-images.githubusercontent.com/20866761/135725116-35e790da-2afe-49f0-95ba-e3c493ed99f5.png)

---

My strong personal preference would be all white but I'd be a lot happier with the greys already. @iHiD finds these labels really important on GitHub too, so there's probably a compromise to be found between hiding them fully white and making them distinguishable through different shades of grey.

---

cc @junedev @sleeplessbyte @bethanyg

See also: https://exercism-team.slack.com/archives/GC3K95MRR/p1633111104089400