### PR TITLE
Change `x:`-label colours to white

### DIFF
--- a/global-files/.github/labels.yml
+++ b/global-files/.github/labels.yml
@@ -22,116 +22,116 @@
 # The `x:action/<value>` labels describe what sort of work the contributor will be engaged in when working on the issue
 - name: "x:action/create"
   description: "Work on something from scratch"
-  color: "6f60d2"
+  color: "ffffff"
 
 - name: "x:action/fix"
   description: "Fix an issue"
-  color: "6f60d2"
+  color: "ffffff"
 
 - name: "x:action/improve"
   description: "Improve existing functionality/content"
-  color: "6f60d2"
+  color: "ffffff"
 
 - name: "x:action/proofread"
   description: "Proofread text"
-  color: "6f60d2"
+  color: "ffffff"
 
 - name: "x:action/sync"
   description: "Sync content with its latest version"
-  color: "6f60d2"
+  color: "ffffff"
 
 # The `x:knowledge/<value>` labels describe how much Exercism knowledge is required by the contributor
 - name: "x:knowledge/none"
   description: "No existing Exercism knowledge required"
-  color: "604fcd"
+  color: "ffffff"
 
 - name: "x:knowledge/elementary"
   description: "Little Exercism knowledge required"
-  color: "604fcd"
+  color: "ffffff"
 
 - name: "x:knowledge/intermediate"
   description: "Quite a bit of Exercism knowledge required"
-  color: "604fcd"
+  color: "ffffff"
 
 - name: "x:knowledge/advanced"
   description: "Comprehensive Exercism knowledge required"
-  color: "604fcd"
+  color: "ffffff"
 
 # The `x:module/<value>` labels indicate what part of Exercism the contributor will be working on
 - name: "x:module/analyzer"
   description: "Work on Analyzers"
-  color: "5240c9"
+  color: "ffffff"
 
 - name: "x:module/concept"
   description: "Work on Concepts"
-  color: "5240c9"
+  color: "ffffff"
 
 - name: "x:module/concept-exercise"
   description: "Work on Concept Exercises"
-  color: "5240c9"
+  color: "ffffff"
 
 - name: "x:module/generator"
   description: "Work on Exercise generators"
-  color: "5240c9"
+  color: "ffffff"
 
 - name: "x:module/practice-exercise"
   description: "Work on Practice Exercises"
-  color: "5240c9"
+  color: "ffffff"
 
 - name: "x:module/representer"
   description: "Work on Representers"
-  color: "5240c9"
+  color: "ffffff"
 
 - name: "x:module/test-runner"
   description: "Work on Test Runners"
-  color: "5240c9"
+  color: "ffffff"
 
 # The `x:size/<value>` labels describe the expected amount of work for a contributor
 - name: "x:size/tiny"
   description: "Tiny amount of work"
-  color: "4836bf"
+  color: "ffffff"
 
 - name: "x:size/small"
   description: "Small amount of work"
-  color: "4836bf"
+  color: "ffffff"
 
 - name: "x:size/medium"
   description: "Medium amount of work"
-  color: "4836bf"
+  color: "ffffff"
 
 - name: "x:size/large"
   description: "Large amount of work"
-  color: "4836bf"
+  color: "ffffff"
 
 - name: "x:size/massive"
   description: "Massive amount of work"
-  color: "4836bf"
+  color: "ffffff"
 
 # The `x:status/<value>` label indicates if there is already someone working on the issue
 - name: "x:status/claimed"
   description: "Someone is working on this issue"
-  color: "4231af"
+  color: "ffffff"
 
 # The `x:type/<value>` labels describe what type of work the contributor will be engaged in
 - name: "x:type/ci"
   description: "Work on Continuous Integration (e.g. GitHub Actions workflows)"
-  color: "3c2d9f"
+  color: "ffffff"
 
 - name: "x:type/coding"
   description: "Write code that is not student-facing content (e.g. test-runners, generators, but not exercises)"
-  color: "3c2d9f"
+  color: "ffffff"
 
 - name: "x:type/content"
   description: "Work on content (e.g. exercises, concepts)"
-  color: "3c2d9f"
+  color: "ffffff"
 
 - name: "x:type/docker"
   description: "Work on Dockerfiles"
-  color: "3c2d9f"
+  color: "ffffff"
 
 - name: "x:type/docs"
   description: "Work on Documentation"
-  color: "3c2d9f"
+  color: "ffffff"
 
 # This label can be added to accept PRs as part of Hacktoberfest
 - name: "hacktoberfest-accepted"


### PR DESCRIPTION
The current colours draw a lot of attention and make it hard to find issues on GitHub for maintainers.

Note that you can overwrite the colours through the `.appends` file by redefining the label on a per-repo basis.