### PR TITLE
sync docker build push image workflow

### DIFF
--- a/tooling-files/.github/workflows/docker.yml
+++ b/tooling-files/.github/workflows/docker.yml
@@ -1,0 +1,21 @@
+name: Build and Push Docker image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-push-image:
+    uses: exercism/github-actions/.github/workflows/docker-build-push-image.yml@main
+    secrets:
+      AWS_ACCOUNT_ID: ${{secrets.AWS_ACCOUNT_ID}}
+      AWS_REGION: ${{secrets.AWS_REGION}}
+      AWS_ECR_ACCESS_KEY_ID: ${{secrets.AWS_ECR_ACCESS_KEY_ID}}
+      AWS_ECR_SECRET_ACCESS_KEY: ${{secrets.AWS_ECR_SECRET_ACCESS_KEY}}
+      DOCKERHUB_USERNAME: ${{secrets.DOCKERHUB_USERNAME}}
+      DOCKERHUB_PASSWORD: ${{secrets.DOCKERHUB_PASSWORD}}


### PR DESCRIPTION
- Support syncing tooling-specific files
- Sync docker-build-push-image workflow to tooling repos

Depends on https://github.com/exercism/org-wide-files/pull/137/files to be merge first.
Only 17c73ba1a1a99e0fb881b3421b88b2ccfeba8c48 should be considered.