### PR TITLE
Update sync-labels workflow to use reusable workflow

### DIFF
--- a/global-files/.github/workflows/sync-labels.yml
+++ b/global-files/.github/workflows/sync-labels.yml
@@ -2,20 +2,18 @@ name: Tools
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
     paths:
       - .github/labels.yml
       - .github/workflows/sync-labels.yml
-  schedule:
-    - cron: 0 0 1 * *
   workflow_dispatch:
+  schedule:
+    - cron: 0 0 1 * * # First day of each month
+
+permissions:
+  issues: write
 
 jobs:
   sync-labels:
-    name: Sync labels
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-      - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: exercism/github-actions/.github/workflows/labels.yml@main


### PR DESCRIPTION
Depends on https://github.com/exercism/github-actions/pull/41/files being merged﻿
