### PR TITLE
Remove CI suffix from configlet workflow

### DIFF
--- a/tracks-files/.github/workflows/configlet.yml
+++ b/tracks-files/.github/workflows/configlet.yml
@@ -1,4 +1,4 @@
-name: Configlet CI
+name: Configlet
 
 on:
   pull_request:


### PR DESCRIPTION
There are three GitHub Actions workflows that are present in many Exercism repositories, but whose contents are identical:

1. Track repos: the workflow to run `configlet lint`
2. Tooling repos: the workflow to deploy the tool as a Docker image
3. All repos: the workflow to sync labels

Having duplicated workflows has two main disadvantages:

1. Updating the workflow means submitting a PR to each repository
2. Each repository gets their own dependabot update PRs

Both of these disadvantages result in (many) notifications for track maintainers, which can be quite annoying.

Solving these problems is done in three steps:

1. We've extracted the shared workflow functionality into reusable workflows that are stored in the exercism/github-actions repository: https://github.com/exercism/github-actions/tree/main/.github/workflows.
2. Modify the workflows currently having duplicated functionality to instead use the reusable workflows.
3. Automatically synchronize the modified workflows from the https://github.com/exercism/org-wide-files repository.

Once all these steps have completed, the three above-mentioned cross-repository workflows:

- will be identical across the different repositories
- will rely on the reusable workflows for their functionality
- won't receive dependabot updates as they don't have versioned github action imports (the reusable workflows use `@main`)
- can easily be updated in a single location without needing bulk PRs

While working on this, we've also made two tiny non-related changes (yeah, this is bad practice, I know :)):

1. We've prepared the `configlet` workflow to allow tracks to opt into also running `configlet fmt` (check the formatting of files in a track's repository). We still need to do a little work in the `org-wide-files` repo to allow track repositories to enable this, but in the end this should be as simple as setting a boolean flag to `true` in a (new) configuration file.
2. The workflows now all have explicit permissions, which improves their security.

Note 1: sometimes we merge minor changes like typo fixes in `org-wide-files` without triggering a bulk PR. Therefore, there might be more files that are synced than just the reusable workflows.

Note 2: there will be a follow-up PR cleaning up duplicate configlet workflows in case the track's configlet workflow has a different name.
