### PR TITLE
Change the repository dispatch type

### DIFF
--- a/.github/workflows/sync-rest.yml
+++ b/.github/workflows/sync-rest.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: ""
   repository_dispatch:
-    types: [appends_update]
+    types: [appends_update, repo_update]
   push:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To trigger a rerun of the syncer for a list of repos, [create a repository dispa
 
 ```json
 {
-  "event_type": "appends_update",
+  "event_type": "repo_update",
   "client_payload": {
     "repos": ["exercism/julia"],
     "pusher": "helpful-user"


### PR DESCRIPTION
This PR changes the repository_dispatch type from `appends_update` to `repo_update`, as we'll also be triggering this when the `.github/org-wide-files-config.toml` file changes.

I've set this to draft to wait until we've updated the website to change the dispatch type too.﻿
