### PR TITLE
deploy: don't run on forked repos

### DIFF
--- a/tooling-files/.github/workflows/deploy.yml
+++ b/tooling-files/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   build-and-push-image:
+    if: github.repository_owner == 'exercism' # Stops this job from running on forks.
     uses: exercism/github-actions/.github/workflows/docker-build-push-image.yml@main
     secrets:
       AWS_ACCOUNT_ID: ${{secrets.AWS_ACCOUNT_ID}}


### PR DESCRIPTION
Tries to stop this from happening:

https://github.com/ee7/exercism-nim-docker-base/actions/runs/2075969416