### PR TITLE
Add reputation labels

### DIFF
--- a/global-files/.github/labels.yml
+++ b/global-files/.github/labels.yml
@@ -87,6 +87,9 @@
   color: "ffffff"
 
 # The `x:rep/<value>` labels describe the amount of reputation to award
+# 
+# For more information on reputation and how these labels should be used,
+# check out https://exercism.org/docs/using/product/reputation
 - name: "x:rep/tiny"
   description: "Tiny amount of reputation"
   color: "ffffff"

--- a/global-files/.github/labels.yml
+++ b/global-files/.github/labels.yml
@@ -86,6 +86,27 @@
   description: "Work on Test Runners"
   color: "ffffff"
 
+# The `x:rep/<value>` labels describe the amount of reputation to award
+- name: "x:rep/tiny"
+  description: "Tiny amount of reputation"
+  color: "ffffff"
+
+- name: "x:rep/small"
+  description: "Small amount of reputation"
+  color: "ffffff"
+
+- name: "x:rep/medium"
+  description: "Medium amount of reputation"
+  color: "ffffff"
+
+- name: "x:rep/large"
+  description: "Large amount of reputation"
+  color: "ffffff"
+
+- name: "x:rep/massive"
+  description: "Massive amount of reputation"
+  color: "ffffff"
+
 # The `x:size/<value>` labels describe the expected amount of work for a contributor
 - name: "x:size/tiny"
   description: "Tiny amount of work"


### PR DESCRIPTION
We want to allow awarding reputation to issues, like we're already doing with PRs.
Unfortunately, for PRs we're using `x:size/X` labels, but these have a distinct meaning for issues in that they describe the expected amount of work for that issue.
We thus came up with the idea to use a _separate_ set of labels: `x:rep/X`.
These labels can be added together with the size labels.
The `x:rep` labels also have the benefit of being more semantic than the `x:size` labels.

See https://github.com/exercism/exercism/issues/6318

Note: a separate PR (to be added later) should be merged together with this PR, which will automatically comment on the usage of `x:size` labels on PRs to point people to using `x:rep`.