### PR TITLE
ci: add workflow to lint whitespace

### DIFF
--- a/.github/bin/lint-whitespace
+++ b/.github/bin/lint-whitespace
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+
+# Change directory to the repo root, so that `git grep`:
+# - Operates on the whole repo, even if this script is called from a subdirectory.
+# - Outputs paths relative to the repo root.
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}" || exit
+exit_status=0
+
+# Check that each git-tracked non-binary file has no trailing whitespace.
+trailing_whitespace="$(git grep --cached -I '[[:blank:]]$')"
+if [ -n "${trailing_whitespace}" ]; then
+  echo "There is trailing whitespace on the below lines:"
+  echo "${trailing_whitespace}"
+  exit_status=1
+fi
+
+# Check that each git-tracked non-binary file has one final newline.
+for file in $(git grep --cached -I --files-with-matches ''); do
+  if [ "$(tail -c 1 "${file}" | wc -l)" -eq 0 ]; then
+    echo "No newline at end of file: ${file}"
+    exit_status=1
+  elif [ "$(tail -c 2 "${file}" | wc -l)" -eq 2 ]; then
+    echo "Multiple newlines at end of file: ${file}"
+    exit_status=1
+  fi
+done
+
+exit "${exit_status}"

--- a/.github/workflows/lint-whitespace.yml
+++ b/.github/workflows/lint-whitespace.yml
@@ -1,0 +1,19 @@
+name: Lint whitespace
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  lint_whitespace:
+    name: Lint whitespace
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - name: Check that every file has no trailing whitespace, and exactly one final newline
+        run: ./.github/bin/lint-whitespace


### PR DESCRIPTION
Enforce that every git-tracked, non-empty text file:
- has no trailing whitespace
- ends in exactly one newline

The script and workflow are [taken from the configlet repo](https://github.com/exercism/configlet/commit/b5908cde0901). 

The script output and factoring can be improved, but it does at least exit non-zero when it's supposed to. 

---

Follow-up from https://github.com/exercism/org-wide-files/pull/204