### PR TITLE
.github/labels: remove trailing whitespace

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -87,7 +87,7 @@
   color: "ffffff"
 
 # The `x:rep/<value>` labels describe the amount of reputation to award
-# 
+#
 # For more information on reputation and how these labels should be used,
 # check out https://exercism.org/docs/using/product/reputation
 - name: "x:rep/tiny"


### PR DESCRIPTION
Reflecting the previous commmit: 28266314296d