### PR TITLE
Replace deprecated set-output command

### DIFF
--- a/.github/workflows/sync-rest.yml
+++ b/.github/workflows/sync-rest.yml
@@ -226,7 +226,7 @@ jobs:
           branch="🤖/org-wide-files/${{ github.run_id }}"
           git checkout -b "$branch"
 
-          echo "::set-output name=name::$branch"
+          echo "name=$branch" >> $GITHUB_OUTPUT
 
       - name: Copy globally synced files to target repo
         if: steps.pr-already-exists.outputs.result == 'false'
@@ -292,7 +292,7 @@ jobs:
             exit 0
           fi
 
-          echo "::set-output name=changes::true"
+          echo "changes=true" >> $GITHUB_OUTPUT
 
       ########################################################
       # ONLY RUN THE REST OF THE SCRIPT IF THERE ARE CHANGES #

--- a/.github/workflows/sync-tooling.yml
+++ b/.github/workflows/sync-tooling.yml
@@ -216,7 +216,7 @@ jobs:
           branch="🤖/org-wide-files/${{ github.run_id }}"
           git checkout -b "$branch"
 
-          echo "::set-output name=name::$branch"
+          echo "name=$branch" >> $GITHUB_OUTPUT
 
       - name: Copy synced files to target repo
         if: steps.pr-already-exists.outputs.result == 'false'
@@ -241,7 +241,7 @@ jobs:
             exit 0
           fi
 
-          echo "::set-output name=changes::true"
+          echo "changes=true" >> $GITHUB_OUTPUT
 
       ########################################################
       # ONLY RUN THE REST OF THE SCRIPT IF THERE ARE CHANGES #

--- a/.github/workflows/sync-tracks.yml
+++ b/.github/workflows/sync-tracks.yml
@@ -216,7 +216,7 @@ jobs:
           branch="🤖/org-wide-files/${{ github.run_id }}"
           git checkout -b "$branch"
 
-          echo "::set-output name=name::$branch"
+          echo "name=$branch" >> $GITHUB_OUTPUT
 
       - name: Copy synced files to target repo
         if: steps.pr-already-exists.outputs.result == 'false'
@@ -241,7 +241,7 @@ jobs:
             exit 0
           fi
 
-          echo "::set-output name=changes::true"
+          echo "changes=true" >> $GITHUB_OUTPUT
 
       ########################################################
       # ONLY RUN THE REST OF THE SCRIPT IF THERE ARE CHANGES #


### PR DESCRIPTION
See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter and https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/