### PR TITLE
Tweak labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -157,11 +157,6 @@
   description: "Work on Documentation"
   color: "ffffff"
 
-# This label can be added to accept PRs as part of Hacktoberfest
-- name: "hacktoberfest-accepted"
-  description: "Make this PR count for hacktoberfest"
-  color: "ff7518"
-
 # This Exercism-wide label is added to all automatically created pull requests that help migrate/prepare a track for Exercism v3
 - name: "v3-migration 🤖"
   description: "Preparing for Exercism v3"

--- a/global-files/.github/labels.yml
+++ b/global-files/.github/labels.yml
@@ -157,12 +157,12 @@
   description: "Work on Documentation"
   color: "ffffff"
 
-# This label can be added to accept PRs as part of Hacktoberfest
-- name: "hacktoberfest-accepted"
-  description: "Make this PR count for hacktoberfest"
-  color: "ff7518"
-
 # This Exercism-wide label is added to all automatically created pull requests that help migrate/prepare a track for Exercism v3
 - name: "v3-migration 🤖"
   description: "Preparing for Exercism v3"
   color: "e99695"
+
+# This Exercism-wide label can be used to bulk-close issues in preparation for pausing community contributions
+- name: "paused"
+  description: "Work paused until further notice"
+  color: "e4e669"


### PR DESCRIPTION
This adds a label `paused` which lets us tag all open issues in a repository and close them,
making it easy to bulk-open them when we have figured out the
volunteering structure.

It also removes `hacktoberfest-accepted` because I think we should not (as an org) encourage participation.
Individual tracks can decide differently a year from now when Hacktoberfest rolls around again.
