### PR TITLE
Treat `request-new-language-track` repo as a track repo when syncing

### DIFF
--- a/.github/workflows/sync-tracks.yml
+++ b/.github/workflows/sync-tracks.yml
@@ -84,6 +84,7 @@ jobs:
               })
 
               return trackRepos.flatMap(({ full_name }) => [full_name])
+                               .concat('exercism/generic-track')
             }
 
       - name: Determine target repos needing to be forked


### PR DESCRIPTION
This PR will ensure that the https://github.com/exercism/request-new-language-track repo will be treated as a track repo when syncing track files.
The consequence of this is that the `request-new-language-track` repo will automatically be kept up-to-date, reducing the number of PRs a new track repo receives.

Closes https://github.com/exercism/org-wide-files/issues/263
