### PR TITLE
Add a backup workflow to all (public) repos.

### DIFF
--- a/global-files/.github/workflows/backup.yml
+++ b/global-files/.github/workflows/backup.yml
@@ -1,0 +1,19 @@
+name: Backup
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: 0 0 * * * # Daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  backup:
+    if: github.repository_owner == 'exercism' # Stops this job from running on forks.
+    name: Backup
+    uses: exercism/github-actions/.github/workflows/backup-repo.yml@backup-repo
+    secrets: inherit


### PR DESCRIPTION
This workflow will backup the repo to a mirror
hosted on AWS CodeCommit.
